### PR TITLE
Allow not passing params et all

### DIFF
--- a/src/angular-filter-count-to.js
+++ b/src/angular-filter-count-to.js
@@ -14,7 +14,7 @@ angular.module('ngCountTo', [])
                     scope.timoutId = null;
                     scope.filter = attrs.filter;
                     scope.fractionSize = attrs.fractionSize ? attrs.fractionSize : 0;
-                    scope.params = attrs.params ? attrs.params : scope.fractionSize;
+                    scope.params = attrs.params ? attrs.params : undefined;
                     ngCountTo = parseFloat(attrs.ngCountTo) || 0;
                     scope.value = parseFloat(attrs.value, 10) || 0;
                     duration = (parseFloat(attrs.duration) * 1000) || 0;


### PR DESCRIPTION
When using currency filter without params (default value, locale), you get "0" (or other fractionSize value), this is a bug.
Angular's currency filters checks, if params are defined, so the quick fix is to undefine params.
